### PR TITLE
update link to installation instructions for pebble

### DIFF
--- a/source/documentation/platforms/pebble.html.haml
+++ b/source/documentation/platforms/pebble.html.haml
@@ -60,7 +60,7 @@ subnavjs: true
   %p The main steps are:
   %ul
     %li Install Pebble 2.0 iOS or Android app. (If you haven't already)
-    %li= link_to "Install watchbot by following this instructions", "https://github.com/hybridgroup/watchbot/raw/master/README.md"
+    %li= link_to "Install watchbot by following this instructions", "https://github.com/hybridgroup/watchbot/blob/master/README.md"
     %li After app is installed, click on "Settings" and configure robot name, robot api host, and robot api port
     %li Configuration settings must match with your program, in this example, api host would be your computer IP, robot name is 'pebble', and robot api port is 8080
 


### PR DESCRIPTION
Currently, the website points to raw markdown file which is not human
readable in the browser. This commit changes link to point to rendered
version.
