### PR TITLE
Corrects gort arduino upload command

### DIFF
--- a/source/documentation/platforms/arduino.html.haml
+++ b/source/documentation/platforms/arduino.html.haml
@@ -88,7 +88,7 @@ subnavjs: true
     Once the `avrdude` uploader is installed, we can upload the Firmata protocol to the Arduino.
     Use the serialport address we found with the earlier `gort`, or leave it blank to use the default address (`/dev/ttyACM0`).
 
-        $ gort arduino upload firmdata /dev/ttyACM0
+        $ gort arduino upload firmata /dev/ttyACM0
 
     Finally, change the connection to the correct serial port.
 

--- a/source/documentation/platforms/arduino.html.haml
+++ b/source/documentation/platforms/arduino.html.haml
@@ -88,7 +88,7 @@ subnavjs: true
     Once the `avrdude` uploader is installed, we can upload the Firmata protocol to the Arduino.
     Use the serialport address we found with the earlier `gort`, or leave it blank to use the default address (`/dev/ttyACM0`).
 
-        $ gort arduino upload /dev/ttyACM0
+        $ gort arduino upload firmdata /dev/ttyACM0
 
     Finally, change the connection to the correct serial port.
 


### PR DESCRIPTION
`gort` command should be `gort arduino upload firmdata <port>` instead of `gort arduino upload <port>`, as stated here http://artoo.io/documentation/getting-started/tutorials/arduino/ and here https://github.com/hybridgroup/gort/issues/38. Following this tutorial leads the user to an error.
